### PR TITLE
Allow credentials store override during app init.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ venv
 coverage
 *.egg-info
 dist
+*.pyc

--- a/flask_oidc/__init__.py
+++ b/flask_oidc/__init__.py
@@ -47,7 +47,6 @@ class OpenIDConnect(object):
         self.urandom = urandom if urandom is not None else os.urandom
 
         # get stuff from the app's config, which may override stuff set above
-        self.app = app
         if app is not None:
             self.init_app(app)
 
@@ -89,7 +88,7 @@ class OpenIDConnect(object):
             pass
 
         try:
-            pass  # TODO: alternate credentials stores from OIDC_CREDENTIALS_STORE
+            self.credentials_store = app.config['OIDC_CREDENTIALS_STORE']
         except KeyError:
             pass
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     url='https://github.com/SteelPangolin/flask-oidc',
     author='Jeremy Ehrhardt',
     author_email='jeremy@bat-country.us',
-    version='0.1.0',
+    version='0.1.1',
     packages=[
         'flask_oidc',
     ],


### PR DESCRIPTION
Fixed a TODO in the code in order to hook flask-oidc up to an app with a bizarre pre-init.
