### PR TITLE
Halt registration for HTTP error codes

### DIFF
--- a/flask_oidc/discovery.py
+++ b/flask_oidc/discovery.py
@@ -24,7 +24,7 @@
 
 import httplib2
 
-from _flask_oidc import _json_loads
+from flask_oidc import _json_loads
 
 
 # OpenID Connect Discovery 1.0

--- a/flask_oidc/registration.py
+++ b/flask_oidc/registration.py
@@ -117,9 +117,12 @@ def register_client(provider_info, redirect_uris):
 
     headers = {'Content-type': 'application/json'}
 
-    _, content = httplib2.Http().request(
+    resp, content = httplib2.Http().request(
         provider_info['registration_endpoint'], 'POST',
         json.dumps(submit_info), headers=headers)
+
+    if int(resp['status']) >= 400:
+        raise Exception('Error: the server returned HTTP ' + resp['status'])
 
     client_info = _json_loads(content)
 


### PR DESCRIPTION
This adds a check for the HTTP response code. If it's 400 or greater
(which covers both client and server errors) an exception is raised
which includes the error code.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>