### PR TITLE
Added options to modify callback and redirect uris.

### DIFF
--- a/flask_oidc/__init__.py
+++ b/flask_oidc/__init__.py
@@ -113,9 +113,11 @@ class OpenIDConnect(object):
         app.config.setdefault('OIDC_USER_INFO_ENABLED', True)
         # Configuration for resource servers
         app.config.setdefault('OIDC_RESOURCE_CHECK_AUD', True)
+        app.config.setdefault('OIDC_CALLBACK_ROUTE', '/oidc_callback')
+        app.config.setdefault('OVERWRITE_REDIRECT_URI', False)
 
         # register callback route and cookie-setting decorator
-        app.route('/oidc_callback')(self._oidc_callback)
+        app.route(app.config['OIDC_CALLBACK_ROUTE'])(self._oidc_callback)
         app.before_request(self._before_request)
         app.after_request(self._after_request)
 
@@ -411,7 +413,11 @@ class OpenIDConnect(object):
         :return:
         """
         flow = copy(self.flow)
-        flow.redirect_uri = url_for('_oidc_callback', _external=True)
+        redirect_uri = current_app.config['OVERWRITE_REDIRECT_URI']
+        if not redirect_uri:
+            flow.redirect_uri = url_for('_oidc_callback', _external=True)
+        else:
+            flow.redirect_uri = redirect_uri
         return flow
 
     def redirect_to_auth_server(self, destination):


### PR DESCRIPTION
I am using flask behind a kubernetes nginx ingress controller and noticed the `redirect_uri` was incorrect because the flask project is mapped to a specific path. I added a simple option to overwrite the `redirect_uri` and another to define the `oidc_callback` route specifically.