### PR TITLE
Issue #25: Make error rendering configurable

### DIFF
--- a/flask_oidc/__init__.py
+++ b/flask_oidc/__init__.py
@@ -685,7 +685,8 @@ class OpenIDConnect(object):
         else:
             return 'Something went wrong checking your token'
 
-    def accept_token(self, require_token=False, scopes_required=None):
+    def accept_token(self, require_token=False, scopes_required=None,
+                           render_errors=True):
         """
         Use this to decorate view functions that should accept OAuth2 tokens,
         this will most likely apply to API functions.
@@ -704,9 +705,14 @@ class OpenIDConnect(object):
             granted by the token before being allowed to call the protected
             function.
         :type scopes_required: list
+        :param render_errors: Whether or not to eagerly render error objects
+            as JSON API responses. Set to False to pass the error object back
+            unmodified for later rendering.
+        :type render_errors: callback(obj) or None
 
         .. versionadded:: 1.0
         """
+
         def wrapper(view_func):
             @wraps(view_func)
             def decorated(*args, **kwargs):
@@ -721,10 +727,11 @@ class OpenIDConnect(object):
                 if (validity is True) or (not require_token):
                     return view_func(*args, **kwargs)
                 else:
-                    return (json.dumps(
-                        {'error': 'invalid_token',
-                         'error_description': validity}),
-                        401, {'WWW-Authenticate': 'Bearer'})
+                    response_body = {'error': 'invalid_token',
+                                     'error_description': validity}
+                    if render_errors:
+                        response_body = json.dumps(response_body)
+                    return response_body, 401, {'WWW-Authenticate': 'Bearer'}
 
             return decorated
         return wrapper

--- a/tests/app.py
+++ b/tests/app.py
@@ -13,10 +13,11 @@ def index():
         'Content-Type': 'text/plain; charset=utf-8'
     }
 
+def raw_api():
+    return {'token': g.oidc_token_info}
 
 def api():
-    return json.dumps({'token': g.oidc_token_info})
-
+    return json.dumps(raw_api())
 
 def create_app(config, oidc_overrides=None):
     app = Flask(__name__)
@@ -25,6 +26,19 @@ def create_app(config, oidc_overrides=None):
         oidc_overrides = {}
     oidc = OpenIDConnect(app, **oidc_overrides)
     app.route('/')(oidc.check(index))
-    app.route('/api', methods=['GET', 'POST'])(
-        oidc.accept_token(True, ['openid'])(api))
+    # Check standalone usage
+    rendered = oidc.accept_token(True, ['openid'])(api)
+    app.route('/api', methods=['GET', 'POST'])(rendered)
+
+    # Check combination with an external API renderer like Flask-RESTful
+    unrendered = oidc.accept_token(True, ['openid'], render_errors=False)(raw_api)
+    def externally_rendered_api(*args, **kwds):
+        inner_response = unrendered(*args, **kwds)
+        if isinstance(inner_response, tuple):
+            raw_response, response_code, headers = inner_response
+            rendered_response = json.dumps(raw_response), response_code, headers
+        else:
+            rendered_response = json.dumps(inner_response)
+        return rendered_response
+    app.route('/external_api', methods=['GET', 'POST'])(externally_rendered_api)
     return app


### PR DESCRIPTION
Uses a simple boolean toggle, as the only supported
cases are eager rendering to JSON (the default),
or delayed rendering handled by an external framework
(such as Flask-RESTful).