### PR TITLE
Token introspection improvements

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -240,6 +240,11 @@ This is a list of all settings supported in the current release.
     "audience" of tokens passed.
     Defaults to False.
 
+  OIDC_INTROSPECTION_AUTH_METHOD
+    String that sets the authentication method used when communicating with
+    the token_introspection_uri.  Valid values are 'client_secret_post',
+    'client_secret_basic', or 'bearer'.  Defaults to 'client_secret_post'.
+
 
 API References
 --------------


### PR DESCRIPTION
* Added OIDC_INTROSPECTION_AUTH_METHOD configuration parameter for
specifying the type of authentication to use when communicating with
the token_introspection_uri.  Options are 'client_secret_post',
'client_secret_basic', and 'bearer'.  Default is 'client_secret_post'.
* View functions decorated with accept_token can now accept tokens
from the Authorization header.