### PR TITLE
split does not take arguments

### DIFF
--- a/flask_oidc/__init__.py
+++ b/flask_oidc/__init__.py
@@ -722,7 +722,7 @@ class OpenIDConnect(object):
             def decorated(*args, **kwargs):
                 token = None
                 if 'Authorization' in request.headers and request.headers['Authorization'].startswith('Bearer '):
-                    token = request.headers['Authorization'].split(maxsplit=1)[1].strip()
+                    token = request.headers['Authorization'].split(None,1)[1].strip()
                 if 'access_token' in request.form:
                     token = request.form['access_token']
                 elif 'access_token' in request.args:


### PR DESCRIPTION
Trying to use the Authorization header I have run into an issue with split not taking keyword arguments

Proof:
Python 2.7.5 (default, Nov  6 2016, 00:28:07) 
[GCC 4.8.5 20150623 (Red Hat 4.8.5-11)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> s = "Bearer aaabbbccc"
>>> s.split(maxsplit=1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: split() takes no keyword arguments
>>> s.split(None,1)[0]
'Bearer'
>>> s.split(None,1)[1]
'aaabbbccc'
>>> s.split(" ",1)[1]
'aaabbbccc'
>>> 

Could you update please?