### PR TITLE
Added decorator to check a client role from Keycloak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 venv
 /client_secrets.json
 /docs/_build
+/build
 .idea
 .coverage
 coverage

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     url='https://github.com/puiterwijk/flask-oidc',
     author='Jeremy Ehrhardt, Patrick Uiterwijk',
     author_email='jeremy@bat-country.us, patrick@puiterwijk.org',
-    version='1.3.0',
+    version='1.3.0_predictx',
     packages=[
         'flask_oidc',
     ],


### PR DESCRIPTION
I needed a way to validate pages in my Flask application against specific roles from Keycloak in the access token and the @accept_token approach wasn't working for html pages. I've added a new decorator function to allow this and return the page or 403 FORBIDDEN. Use as follows:
```
@app.route("/private")
@oidc.require_login
@iodc.require_role('keycloak_client', 'keycloak_role')
def private():
    return "Hello"
```