### PR TITLE
fix encoding for basic auth (fixes #49)

### DIFF
--- a/flask_oidc/__init__.py
+++ b/flask_oidc/__init__.py
@@ -882,7 +882,7 @@ class OpenIDConnect(object):
         if (auth_method == 'client_secret_basic'):
             basic_auth_string = '%s:%s' % (self.client_secrets['client_id'], self.client_secrets['client_secret'])
             basic_auth_bytes = bytearray(basic_auth_string, 'utf-8')
-            headers['Authorization'] = 'Basic %s' % b64encode(basic_auth_bytes)
+            headers['Authorization'] = 'Basic %s' % b64encode(basic_auth_bytes).decode('utf-8')
         elif (auth_method == 'bearer'):
             headers['Authorization'] = 'Bearer %s' % token
         elif (auth_method == 'client_secret_post'):


### PR DESCRIPTION
Simply adding a .decode('utf-8') fixes the wrong encoding in the header, when using flask-oidc from python3.

To reproduce, use the resource server flow (in my case: @oidc.accept_token) and observe whether authentication to OIDC Provider works well.