### PR TITLE
Support token introspection on tokens obtained via the implicit grant type

### DIFF
--- a/flask_oidc/__init__.py
+++ b/flask_oidc/__init__.py
@@ -887,7 +887,8 @@ class OpenIDConnect(object):
             headers['Authorization'] = 'Bearer %s' % token
         elif (auth_method == 'client_secret_post'):
             request['client_id'] = self.client_secrets['client_id']
-            request['client_secret'] = self.client_secrets['client_secret']
+            if self.client_secrets['client_secret'] is not None:
+                request['client_secret'] = self.client_secrets['client_secret']
 
         resp, content = httplib2.Http().request(
             self.client_secrets['token_introspection_uri'], 'POST',


### PR DESCRIPTION
Since authentication via the implicit grant type doesn't involve client secrets, `client_secret` shouldn't be part of the POST body when introspecting a token. Supplying `client_secret` when it isn't necessary can cause problems with certain OpenID Connect providers.