### PR TITLE
Fix for single audience in a list of audiences in id_token

### DIFF
--- a/flask_oidc/__init__.py
+++ b/flask_oidc/__init__.py
@@ -584,6 +584,9 @@ class OpenIDConnect(object):
                          % id_token['iss'])
             return False
 
+         if 'aud' in id_token and isinstance(id_token['aud'], list) and len(id_token['aud']) == 1:
+            id_token['aud'] = id_token['aud'][0]
+            
         if isinstance(id_token['aud'], list):
             # step 3 for audience list
             if self.flow.client_id not in id_token['aud']:

--- a/flask_oidc/__init__.py
+++ b/flask_oidc/__init__.py
@@ -103,7 +103,8 @@ class OpenIDConnect(object):
     The core OpenID Connect client object.
     """
     def __init__(self, app=None, credentials_store=None, http=None, time=None,
-                 urandom=None):
+                 urandom=None, provider=None):
+
         self.credentials_store = credentials_store\
             if credentials_store is not None\
             else MemoryCredentials()
@@ -119,9 +120,23 @@ class OpenIDConnect(object):
         # By default, we do not have a custom callback
         self._custom_callback = None
 
+        # In the beginning we know nothing ...
+        self.client_secrets = None
+
         # get stuff from the app's config, which may override stuff set above
-        if app is not None:
+        
+        if app:
             self.init_app(app)
+
+        if provider:
+            self.init_provider(app, provider)
+
+    def __exit__(self, exception_type, exception_value, traceback):
+        self.logout()
+
+        self.client_secrets = None
+
+        current_app.config['OIDC_VALID_ISSUERS'] = None
 
     def init_app(self, app):
         """
@@ -130,11 +145,9 @@ class OpenIDConnect(object):
         :param app: The application to initialize.
         :type app: Flask
         """
-        secrets = self.load_secrets(app)
-        self.client_secrets = list(secrets.values())[0]
-        secrets_cache = DummySecretsCache(secrets)
 
         # Set some default configuration options
+        app.config.setdefault('OIDC_CLIENT_SECRETS', None)
         app.config.setdefault('OIDC_SCOPES', ['openid', 'email'])
         app.config.setdefault('OIDC_GOOGLE_APPS_DOMAIN', None)
         app.config.setdefault('OIDC_ID_TOKEN_COOKIE_NAME', 'oidc_id_token')
@@ -169,13 +182,6 @@ class OpenIDConnect(object):
             app.before_request(self._before_request)
             app.after_request(self._after_request)
 
-        # Initialize oauth2client
-        self.flow = flow_from_clientsecrets(
-            app.config['OIDC_CLIENT_SECRETS'],
-            scope=app.config['OIDC_SCOPES'],
-            cache=secrets_cache)
-        assert isinstance(self.flow, OAuth2WebServerFlow)
-
         # create signers using the Flask secret key
         self.extra_data_serializer = JSONWebSignatureSerializer(
             app.config['SECRET_KEY'])
@@ -187,11 +193,115 @@ class OpenIDConnect(object):
         except KeyError:
             pass
 
-    def load_secrets(self, app):
-        # Load client_secrets.json to pre-initialize some configuration
-        return _json_loads(open(app.config['OIDC_CLIENT_SECRETS'],
-                                   'r').read())
-        
+    def init_provider(self, provider):
+        """
+        Do setup for a specific provider
+
+        :param provider: The provider to initialize.
+        :type provider: Dictionary with at lease 'base_url' item
+        """
+
+        secrets = self.load_secrets(provider)
+        assert secrets != None, "Problem with loading secrets"
+
+        self.client_secrets = list(secrets.values())[0]
+        secrets_cache = DummySecretsCache(secrets)
+
+        # Initialize oauth2client
+        self.flow = flow_from_clientsecrets(
+            current_app.config['OIDC_CLIENT_SECRETS'],
+            scope=current_app.config['OIDC_SCOPES'],
+            cache=secrets_cache)
+
+        assert isinstance(self.flow, OAuth2WebServerFlow)
+
+        current_app.config['OIDC_VALID_ISSUERS'] = self.client_secrets.get('issuer')
+
+    def load_secrets(self, provider):
+
+        try:
+            static_secrets = current_app.config.get('OIDC_CLIENT_SECRETS', None)
+            if static_secrets:
+                return _json_loads(open(static_secrets,'r').read())
+        except Exception as e:
+            raise Exception("Error reading secrets: {}, error: {}".format(static_secrets, str(e)))
+
+        if not provider:
+            raise Exception("No Provider specified")
+
+        try:
+            url = provider.get('base_url')
+
+            if not url.endswith('/'):
+                url += '/'
+
+            url += ".well-known/openid-configuration"
+
+            logger.debug("Loading: {}".format(url))
+
+            provider_info = json.load(
+                urllib.request.urlopen(url)
+            )
+
+        except Exception as e:
+            raise Exception("Can not obtain well known information: {}".format(str(e)))
+
+        for path in ['issuer', 'registration_endpoint', 'authorization_endpoint', 'token_endpoint', 'userinfo_endpoint', 'jwks_uri']:
+            if path in provider_info and provider_info[path].startswith('/'):
+                provider_info[path] = "{}{}".format(provider.get('base_url'), provider_info[path])
+
+        registration = provider.get('registration', None)
+
+        if not registration:
+            try:
+                logger.debug("Dynamic Registration...")
+
+                registration = requests.post(
+                    provider_info['registration_endpoint'],
+                    data = json.dumps({
+                        "redirect_uris": REDIRECT_URL,
+                        "grant_types": "authorization_code",
+                        "client_name": provider.get('client_name', "Dynamic Registration"),
+                        "response_types": "code",
+                        "token_endpoint_auth_method": "client_secret_post",
+                        "application_type": "native"
+                    }),
+                    headers = {
+                        'Content-Type': "application/json",
+                        'Cache-Control': "no-cache"
+                    }
+                ).json()
+
+                logger.debug("Registration: {}".format(registration))
+
+            except Exception as e:
+                raise Exception("Can not make client registration: {}".format(str(e)))
+
+        try:
+            try:
+               jwks_keys = json.load(
+                 urllib.request.urlopen(provider_info['jwks_uri'])
+               )
+            except:
+               jwks_keys = None
+
+            return {
+                'web' : {
+                    'client_id': registration.get('client_id'),
+                    'client_secret': registration.get('*client_secret*', registration.get('client_secret', None)),
+                    'auth_uri': provider_info['authorization_endpoint'],
+                    'token_uri': provider_info['token_endpoint'],
+                    'userinfo_uri': provider_info['userinfo_endpoint'],
+                    'jwks_keys': jwks_keys,
+                    'redirect_uris': REDIRECT_URL,
+                    'issuer': provider_info['issuer'],
+                }
+            }
+        except Exception as e:
+            raise Exception("Error in preparing result: {}".format(str(e)))
+
+        raise Exception("No secrets loaded !")
+            
     @property
     def user_loggedin(self):
         """
@@ -404,7 +514,9 @@ class OpenIDConnect(object):
 
     def _before_request(self):
         g.oidc_id_token = None
-        self.authenticate_or_redirect()
+
+        if self.client_secrets:
+            self.authenticate_or_redirect()
 
     def authenticate_or_redirect(self):
         """
@@ -567,6 +679,16 @@ class OpenIDConnect(object):
         self._set_cookie_id_token(None)
         return redirect(auth_url)
 
+    def token(self):
+        try:
+            return self.credentials_store[g.oidc_id_token['sub']]
+        except KeyError:
+            logger.debug("No Token !", exc_info=True)
+            return None
+
+    def details(self):
+        return self._retrieve_userinfo()
+
     def _is_id_token_valid(self, id_token):
         """
         Check if `id_token` is a current ID token for this application,
@@ -584,7 +706,7 @@ class OpenIDConnect(object):
                          % id_token['iss'])
             return False
 
-        # Make sure that we only have a list of audiende when there are more than 1...
+        # Make sure that we only have a list of audiende when there are more than 1...chec
         if 'aud' in id_token and isinstance(id_token['aud'], list) and len(id_token['aud']) == 1:
             id_token['aud'] = id_token['aud'][0]
 

--- a/flask_oidc/__init__.py
+++ b/flask_oidc/__init__.py
@@ -584,9 +584,10 @@ class OpenIDConnect(object):
                          % id_token['iss'])
             return False
 
-         if 'aud' in id_token and isinstance(id_token['aud'], list) and len(id_token['aud']) == 1:
+        # Make sure that we only have a list of audiende when there are more than 1...
+        if 'aud' in id_token and isinstance(id_token['aud'], list) and len(id_token['aud']) == 1:
             id_token['aud'] = id_token['aud'][0]
-            
+
         if isinstance(id_token['aud'], list):
             # step 3 for audience list
             if self.flow.client_id not in id_token['aud']:


### PR DESCRIPTION
The check the validity of a id_token is failing when the id_token contains an 'aud' attribute representing a list of just a single audience party and the id_token does not contain 'azp', then the error will be raised 'Multiple audiences and not authorized party'.