### PR TITLE
Dynamic Provider

### DIFF
--- a/flask_oidc/__init__.py
+++ b/flask_oidc/__init__.py
@@ -141,7 +141,7 @@ class OpenIDConnect(object):
 
         self.client_secrets = None
 
-        current_app.config['OIDC_VALID_ISSUERS'] = []
+        current_app.config['OIDC_VALID_ISSUERS'] = GOOGLE_ISSUERS
 
     def init_app(self, app):
         """
@@ -218,7 +218,7 @@ class OpenIDConnect(object):
 
         assert isinstance(self.flow, OAuth2WebServerFlow)
 
-        current_app.config['OIDC_VALID_ISSUERS'] = (self.client_secrets.get('issuer') or [])
+        current_app.config['OIDC_VALID_ISSUERS'] = (self.client_secrets.get('issuer') or GOOGLE_ISSUERS)
 
     def load_secrets(self, provider):
 


### PR DESCRIPTION
Add ability to connect to an OIDC OP at Runtime. For backwards compatibility the existing config option OIDC_CLIENT_SECRETS is still supported. 

Usage for dynamic OP connectivity is:

Initialize the Flask App as normal:
```
app = Flask(__name__)
oidc =  OpenIDConnect(app)
```

Specify the Provider to connect with:
```
my_provider = { 
   'base_url': 'https://example.org' , 
   'registration': { 'client_id': 'xxx', 'client_secret': 'yyy' }
} 
```

Now finalize the configuration for this OIDC Provider (meaning the discovery will take place)
```
oidc.init_provider(my_provider)
```

And use the authentication as normal:
```
@app.route('/private')
@oidc.require_login
def private():
   ...
```