### PR TITLE
Fix typo (Flask-OpenID -> Flask-OIDC)

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,7 +30,7 @@ Install the extension with `pip`::
 How to use
 ----------
 
-To integrate Flask-OpenID into your application you need to create an
+To integrate Flask-OIDC into your application you need to create an
 instance of the :class:`OpenID` object first::
 
     from flask_oidc import OpenIDConnect


### PR DESCRIPTION
While I'm here, may I also ask what is the relationship between Flask-OIDC and Flask-OpenID? They seem related, but neither seems to be a drop-in replacement for the other, and neither's docs mention this. All I can tell is that Flask-OpenID has a much higher "Used by" count on GitHub (currently 3k vs. 169), Flask-OpenID is less frequently and recently updated, and this project's maintainer, @puiterwijk, appears to have taken over maintenance of Flask-OpenID as well (hence this typo?:).

Thanks in advance for any clarification!