### PR TITLE
Update __init__.py

### DIFF
--- a/flask_oidc/__init__.py
+++ b/flask_oidc/__init__.py
@@ -513,7 +513,7 @@ class OpenIDConnect(object):
             @wraps(view_func)
             def decorated(*args, **kwargs):
                 pre, tkn, post = self.get_access_token().split('.')
-                access_token = json.loads(b64decode(tkn))
+                access_token = json.loads(b64decode(tkn + ('=' * (len(tkn) % 4))))
                 if role in access_token['resource_access'][client]['roles']:
                     return view_func(*args, **kwargs)
                 else:


### PR DESCRIPTION
binascii.Error: Incorrect padding fix
keycloak doesnt add '=' for proper padding