### PR TITLE
ValueError is uncaught when credentials_store is missing a Key

### DIFF
--- a/flask_oidc/__init__.py
+++ b/flask_oidc/__init__.py
@@ -445,6 +445,10 @@ class OpenIDConnect(object):
                 logger.debug("Expired ID token, credentials missing",
                              exc_info=True)
                 return self.redirect_to_auth_server(request.url)
+            except ValueError:
+                logger.debug("Credentials missing",
+                             exc_info=True)
+                return self.redirect_to_auth_server(request.url)
 
             # refresh and store credentials
             try:


### PR DESCRIPTION
This returns None and throws an uncaught error. 
Fixes #128 
