### PR TITLE
Itsdangerous replacement with PyJWT

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "docs/_themes"]
-	path = docs/_themes
-	url = git://github.com/mitsuhiko/flask-sphinx-themes.git

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include README.rst LICENSE.rst CHANGES.rst
+include requirements.txt README.rst LICENSE.rst CHANGES.rst
 recursive-include docs *
 recursive-exclude docs *.pyc
 recursive-exclude docs *.pyo

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -6,6 +6,7 @@ SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build
+THEMESDIR      = _themes
 
 # User-friendly check for sphinx-build
 ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
@@ -52,6 +53,10 @@ help:
 .PHONY: clean
 clean:
 	rm -rf $(BUILDDIR)/*
+	rm -rf $(THEMESDIR)/*
+	git clone git://github.com/mitsuhiko/flask-sphinx-themes.git $(THEMESDIR)
+	@echo
+	@echo "Clones Sphinx themes into $(THEMESDIR)"
 
 .PHONY: html
 html:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Flask
-itsdangerous
+PyJWT
 oauth2client
 six

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import sys
 from setuptools import setup
 
 # This check is to make sure we checkout docs/_themes before running sdist
-if not os.path.exists("./docs/_themes/README"):
+if "sdist" in sys.argv and not os.path.exists("./docs/_themes/README"):
     print('Please make sure you have docs/_themes checked out while running setup.py!')
     if os.path.exists('.git'):
         print('You seem to be using a git checkout, please execute the following commands to get the docs/_themes directory:')

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,8 @@ if "sdist" in sys.argv and not os.path.exists("./docs/_themes/README"):
 here = os.path.abspath(os.path.dirname(__file__))
 with io.open(os.path.join(here, 'README.rst')) as f:
     readme = f.read()
+with io.open(os.path.join(here, 'requirements.txt')) as f:
+    requirements = f.read().split()
 
 setup(
     name='flask-oidc',
@@ -30,13 +32,8 @@ setup(
     version='1.4.0',
     packages=[
         'flask_oidc',
-    ],
-    install_requires=[
-        'Flask',
-        'itsdangerous',
-        'oauth2client',
-        'six',
-    ],
+    ],  
+    install_requires=requirements,
     tests_require=['nose', 'mock'],
     entry_points={
         'console_scripts': ['oidc-register=flask_oidc.registration_util:main'],


### PR DESCRIPTION
Newer versions of Itsdangerous (i.e. 2.1.1) no longer have support for JWT encoding and/or decoding (https://github.com/pallets/itsdangerous/blob/d1c85670cce70d81f9949619434daf8c0b9cd37e/src/itsdangerous/jws.py#L23-L30). This is a breaking change for flask-oidc. This PR replaces the itsdangerous functionality with PyJWT.