### PR TITLE
Add setup requires

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "docs/_themes"]
 	path = docs/_themes
-	url = git://github.com/mitsuhiko/flask-sphinx-themes.git
+	url = git@github.com:pallets/flask-sphinx-themes.git

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         'six',
     ],
     tests_require=['nose', 'mock'],
+    setup_requires=['nose', 'mock'],
     entry_points={
         'console_scripts': ['oidc-register=flask_oidc.registration_util:main'],
     },


### PR DESCRIPTION
This change allows running `python setup.py nosetests` directly without having to install nose first. Ref: https://nose.readthedocs.io/en/latest/api/commands.html