### PR TITLE
fixing missing exception when signature expired and change submodule from git to https git

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "docs/_themes"]
 	path = docs/_themes
-	url = git://github.com/mitsuhiko/flask-sphinx-themes.git
+	url = https://github.com/mitsuhiko/flask-sphinx-themes.git

--- a/flask_oidc/__init__.py
+++ b/flask_oidc/__init__.py
@@ -38,7 +38,7 @@ from flask import request, session, redirect, url_for, g, current_app, abort
 from oauth2client.client import flow_from_clientsecrets, OAuth2WebServerFlow,\
     AccessTokenRefreshError, OAuth2Credentials
 import httplib2
-from itsdangerous import JSONWebSignatureSerializer, BadSignature
+from itsdangerous import JSONWebSignatureSerializer, BadSignature, SignatureExpired
 
 __all__ = ['OpenIDConnect', 'MemoryCredentials']
 


### PR DESCRIPTION
This PR fixes 2 issues I found when using flask-oidc pack. 

1. When the token expires, it raise an exception of type `SignatureExpired`, this exception class is in the package but not imported.
2. when installing flask-oidc from GitHub using `pip -r requirements.txt`,  it gives an error while cloning the submodule. Changed the protocol of submodule from `git` to `https` solves this issue. 

The second issue only occurs when installing directly from GitHub. And users need the `master` branch on GitHub as it fixes issues which block usual auth action and always return `401 Not Authorised`

 